### PR TITLE
General cleanup: added constant for `block_size`

### DIFF
--- a/apfs.ksy.yml
+++ b/apfs.ksy.yml
@@ -4,9 +4,12 @@ meta:
 seq:
  - id: blocks
    type: block
-   size: 4096
+   size: block_size
    repeat: until
-   repeat-until: _io.size - _io.pos < 4096
+   repeat-until: _io.size - _io.pos < block_size
+instances:
+  block_size:
+    value: 4096
 types:
 # meta structs
   block_header:
@@ -43,8 +46,6 @@ types:
             blocktypes::btree: btree
             blocktypes::checkpoint: checkpoint
             blocktypes::volumesuperblock: volumesuperblock
-      - id: padding
-        size: (4096 - _io.pos) % 4096
 
 # special files
   containersuperblock:
@@ -267,7 +268,7 @@ types:
         # size: header.key_length + 8
         type: key
       record:
-        pos: 4096 - header.data_offset - 40
+        pos: _root.block_size - header.data_offset - 40
         size: header.data_length
         type:
           switch-on: key.type
@@ -288,7 +289,7 @@ types:
             0xB: fixed_loc_key
             _: fixed_key
       record:
-        pos: 4096-header.data_offset-40
+        pos: _root.block_size - header.data_offset - 40
         type: 
           switch-on: _parent._parent.header.padding
           cases:


### PR DESCRIPTION
* Moved "4096" to a top-level constant `block_size`. Use that `block_size` everywhere applicable.
* Removed `padding` from `block`, as it serves no purpose anyway: the only invocation of `block` has clear constraint `size: block_size`, thus `block` would always be exactly 4096 bytes, no matter what.