### PR TITLE
Filling out item_type

### DIFF
--- a/apfs.ksy
+++ b/apfs.ksy
@@ -715,10 +715,10 @@ enums:
   item_type:
     1: named_pipe
     2: character_special
-    4: folder
-    6: block_device
-    8: file
-    10: symlink
+    4: directory
+    6: block_special
+    8: regular
+    10: symbolic_link
     12: socket
     14: whiteout
 

--- a/apfs.ksy
+++ b/apfs.ksy
@@ -713,9 +713,14 @@ enums:
     #   Sparse_bytes
 
   item_type:
+    1: named_pipe
+    2: character_special
     4: folder
+    6: block_device
     8: file
     10: symlink
+    12: socket
+    14: whiteout
 
   ea_type:
     2: generic


### PR DESCRIPTION
After testing more kinds of special file, values in item_type correspond with these values in the stat(2) man page:

    #define        S_IFIFO  0010000  /* named pipe (fifo) */
    #define        S_IFCHR  0020000  /* character special */
    #define        S_IFDIR  0040000  /* directory */
    #define        S_IFBLK  0060000  /* block special */
    #define        S_IFREG  0100000  /* regular */
    #define        S_IFLNK  0120000  /* symbolic link */
    #define        S_IFSOCK 0140000  /* socket */
    #define        S_IFWHT  0160000  /* whiteout */