### PR TITLE
Changing check for whether a node is an index node

### DIFF
--- a/apfs.ksy
+++ b/apfs.ksy
@@ -215,7 +215,7 @@ types:
       val:
         pos: _root.block_size - data_offset - 40 * (_parent.node_type & 1)
         type:
-          switch-on: '(((_parent.node_type & 2) == 0) ? 256 : 0) + key_hdr.kind.to_i * (((_parent.node_type & 2) == 0) ? 0 : 1)'
+          switch-on: '(_parent.level > 0) ? 256 : key_hdr.kind.to_i'
           cases:
             256: pointer_val # applies to all pointer vals, i.e. any entry val in index nodes
             kind::omap.to_i: omap_val


### PR DESCRIPTION
I wasn't 100% certain that `node_type & 2 == 0` meant a branch/index node, whereas `level > 0` is certain since that's the meaning of the field.