### PR TITLE
Filling in additional size fields

### DIFF
--- a/apfs.ksy
+++ b/apfs.ksy
@@ -387,6 +387,14 @@ types:
     seq:
       - id: size
         type: u8
+      - id: stored_size
+        type: u8
+      - id: unknown_16
+        type: u8
+      - id: unknown_size # could be compressed size
+        type: u8
+      - id: unknown_32
+        type: u8
 
   xf_header:
     seq:


### PR DESCRIPTION
The size details inside the inode also contains the stored size (rounded up to block size, essentially), plus one more mystery size which could be the compressed size if the format has that planned for the future.