### PR TITLE
Renaming extent_status_val -> extent_refcount_val

### DIFF
--- a/apfs.ksy
+++ b/apfs.ksy
@@ -223,7 +223,7 @@ types:
             kind::drec.to_i: drec_val
             kind::inode.to_i: inode_val
             kind::sibling.to_i: sibling_val
-            kind::extent_status.to_i: extent_status_val
+            kind::extent_refcount.to_i: extent_refcount_val
             kind::extent.to_i: extent_val
             kind::entry12.to_i: t12_val
             kind::xattr.to_i: xattr_val
@@ -716,7 +716,7 @@ enums:
     0x3: inode
     0x4: xattr
     0x5: sibling
-    0x6: extent_status
+    0x6: extent_refcount
     0x8: extent
     0x9: drec
     0xc: entry12

--- a/apfs.ksy
+++ b/apfs.ksy
@@ -228,7 +228,7 @@ types:
             kind::entry12.to_i: t12_val
             kind::xattr.to_i: xattr_val
         -webide-parse-mode: eager
-    -webide-representation: '{key_hdr}: {val}'
+    -webide-representation: '{key_hdr} -> {val}'
 
 ## node entry keys
 
@@ -246,7 +246,7 @@ types:
         value: key_high >> 28
         enum: kind
         -webide-parse-mode: eager
-    -webide-representation: '({kind}) {key_value:dec} {content}'
+    -webide-representation: '({kind}) {obj_id:dec}'
 
   omap_key:
     seq:
@@ -326,7 +326,7 @@ types:
     seq:
       - id: parent_id
         type: u8
-      - id: node_id
+      - id: extents_id
         type: u8
       - id: creation_timestamp
         type: u8
@@ -377,7 +377,7 @@ types:
             xfield_type::name: xf_name
             xfield_type::size: xf_size
             xfield_type::device_node: xf_device_node
-    -webide-representation: '#{node_id:dec} / #{parent_id:dec} {xf_used_data}'
+    -webide-representation: '#{extents_id:dec} / #{parent_id:dec} {xf_used_data}'
 
   xf_name:
     seq:
@@ -426,9 +426,9 @@ types:
         type: str
     -webide-representation: '#{node_id:dec} "{name}"'
 
-  extent_status_val: # 0x60
+  extent_refcount_val: # 0x60
     seq:
-      - id: extent_count
+      - id: count
         type: u4
     -webide-representation: '{unknown_0}'
 


### PR DESCRIPTION
So this answers the question about the mysterious record before the extents, but also answers a question I hadn't yet voiced about why there was a `node_id` inside the `inode_val` structure despite already having the ID in the key. Turns out it can be different.

Behavioural notes:

* Newly created non-empty files always have extent refcount 1 and the extents are stored under the file's own node ID.
* When you clone a file using `cp -c file1 file2`:
    * `file1`'s extent refcount gets incremented
    * `file2`'s inode will refer to `file1` as the source of extent data (extents ID)
* When you then modify `file2`:
    * `file1`'s extent refcount gets decremented
    * `file2`'s extents ID extend will now refer to a _new_ node ID (for some reason they don't put them into `file2`'s own node ID...)
    * a new node ID will appear in the files table which has no inode entry, just extent_refcount and extent records

Note: I tried creating gigantic sparse files and then modifying only part of the file, and it seemed to clone all the extents even though I only modified one extent, but it's unknown whether this would also occur for large non-sparse files, so more experiments might be a good idea.