### PR TITLE
Modification log stores up to 9 records

### DIFF
--- a/apfs.ksy
+++ b/apfs.ksy
@@ -671,24 +671,26 @@ types:
         size: 16
       - id: last_mod_time
         type: u8
-      - id: formatted_by_last_xid
-        type: u8
-      - id: formatted_by_id
-        size: 32
-        type: strz
-      - id: formatted_by_timestamp
-        type: u8
-      - id: modified_by_last_xid
-        type: u8
-      - id: modified_by_id
-        type: strz
-        size: 32
-      - id: modified_by_timestamp
-        type: u8
+      - id: formatted_by
+        type: volume_access_info
+      - id: modified_by
+        type: volume_access_info
+        repeat: expr
+        repeat-expr: 9
       - id: rest
         size: 344
       - id: volname
         type: strz
+
+  volume_access_info:
+    seq:
+      - id: last_xid
+        type: u8
+      - id: id
+        size: 32
+        type: strz
+      - id: timestamp
+        type: u8
 
 # enums
 

--- a/apfs.ksy
+++ b/apfs.ksy
@@ -677,8 +677,8 @@ types:
         type: volume_access_info
         repeat: expr
         repeat-expr: 8
-      - id: rest
-        size: 344
+      - id: unknown_xid
+        type: u8
       - id: volname
         type: strz
 

--- a/apfs.ksy
+++ b/apfs.ksy
@@ -671,25 +671,25 @@ types:
         size: 16
       - id: last_mod_time
         type: u8
+      - id: encryption_flags
+        type: u8
       - id: formatted_by
         type: volume_access_info
       - id: modified_by
         type: volume_access_info
         repeat: expr
         repeat-expr: 8
-      - id: unknown_xid
-        type: u8
       - id: volname
         type: strz
 
   volume_access_info:
     seq:
-      - id: last_xid
-        type: u8
       - id: id
         size: 32
         type: strz
       - id: timestamp
+        type: u8
+      - id: xid
         type: u8
 
 # enums

--- a/apfs.ksy
+++ b/apfs.ksy
@@ -676,7 +676,7 @@ types:
       - id: modified_by
         type: volume_access_info
         repeat: expr
-        repeat-expr: 9
+        repeat-expr: 8
       - id: rest
         size: 344
       - id: volname


### PR DESCRIPTION
I made 12 modifications to the disk in separate sessions to see what would happen to the modification log.

Turns out that the original record for formatting the image remains, but other modification entries get pushed off the bottom of the log such that the latest one is always first.

```
00000000  6e 65 77 66 73 5f 61 70  66 73 20 28 37 34 38 2e  |newfs_apfs (748.|
00000010  35 37 2e 31 39 29 00 00  00 00 00 00 00 00 00 00  |57.19)..........|
00000020  3e 17 0f d6 2a ac 32 15  02 00 00 00 00 00 00 00  |>...*.2.........|

00000030  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
00000040  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
00000050  55 4c 3b 69 2c ac 32 15  1d 00 00 00 00 00 00 00  |UL;i,.2.........|

00000060  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
00000070  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
00000080  d0 fd fb 4b 2c ac 32 15  1c 00 00 00 00 00 00 00  |...K,.2.........|

00000090  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
000000a0  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
000000b0  6d 5c 2f 2e 2c ac 32 15  1b 00 00 00 00 00 00 00  |m\/.,.2.........|

000000c0  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
000000d0  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
000000e0  4e d2 e5 10 2c ac 32 15  1a 00 00 00 00 00 00 00  |N...,.2.........|

000000f0  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
00000100  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
00000110  de 92 fa f2 2b ac 32 15  19 00 00 00 00 00 00 00  |....+.2.........|

00000120  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
00000130  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
00000140  18 4e 4f d6 2b ac 32 15  18 00 00 00 00 00 00 00  |.NO.+.2.........|

00000150  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
00000160  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
00000170  81 24 fd b7 2b ac 32 15  17 00 00 00 00 00 00 00  |.$..+.2.........|

00000180  61 70 66 73 5f 6b 65 78  74 20 63 6f 6d 70 69 6c  |apfs_kext compil|
00000190  65 64 20 40 20 41 70 72  20 31 33 20 32 30 31 00  |ed @ Apr 13 201.|
000001a0  d1 2f 8a 9b 2b ac 32 15  16 00 00 00 00 00 00 00  |./..+.2.........|

```