### PR TITLE
Few corrections (omap_key, extent_val, xattr_key)

### DIFF
--- a/apfs.ksy
+++ b/apfs.ksy
@@ -208,7 +208,7 @@ types:
             kind::omap: omap_key
             kind::lookup: lookup_key
             kind::inode: empty_key
-            kind::xattr: drec_key
+            kind::xattr: xattr_key
             kind::sibling: sibling_key
             kind::extent_refcount: empty_key
             kind::extent: extent_key
@@ -258,9 +258,7 @@ types:
     seq:
       - id: xid
         type: u8
-      - id: oid
-        type: u8
-    -webide-representation: 'ID {oid:dec} v{xid:dec}'
+    -webide-representation: 'XID {xid:dec}'
 
   history_key:
     seq:
@@ -280,11 +278,17 @@ types:
     seq:
       - id: name_length
         type: u1
-      - id: flag_1
+      - id: hash
+        size: 3
+      - id: name
+        size: name_length
+        type: strz
+    -webide-representation: '"{name}"'
+
+  xattr_key:
+    seq:
+      - id: name_length
         type: u1
-      - id: unknown_2
-        type: u2
-#        if: flag_1 != 0
       - id: name
         size: name_length
         type: strz
@@ -463,7 +467,7 @@ types:
       - id: len
         type: u8
       - id: phys_block_num
-        type: ref_obj
+        type: u8
       - id: flags
         type: u8
     -webide-representation: '{phys_block_num}, Len {len:dec}, {flags:dec}'


### PR DESCRIPTION
Based on some tests on my sample APFS disks, I've make the following corrections.
Added xattr_key. It is different from drec_key. drec_key has 3 byte hash, but xattr_key does not. 
Changed extent_val phys_block_num to number from ref_obj. This is just a block number.
Removed oid field from omap_key. omap_key is only 8 bytes in size. Discovered this as previously defined oid field was overlapping with other keys.